### PR TITLE
update readME - getRandomFact()

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const { Feed, Reader } = require('slashtags-widget-facts-feed');
   const reader = new Reader(readerClient, feed.url)
 
   const facts = await reader.getAllFacts()
-  const random = await reader.getRandomFacts()
+  const random = await reader.getRandomFact()
 })
 ```
 


### PR DESCRIPTION
There is a small typo in the readME file, the mentioned function getRandomFacts() does not exist, you need to use getRandomFact() to work